### PR TITLE
[MISC] Add missing libreadline

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,6 +21,7 @@ parts:
             - ca-certificates
             - tzdata
             - logrotate
+            - libreadline8
     non-root-user:
         plugin: nil
         after: [pgbouncer-snap]


### PR DESCRIPTION
Rock's bundled psql fails due to missing dep:
```
root@9a084b68a4ac:/# psql
/usr/lib/postgresql/14/bin/psql: error while loading shared libraries: libreadline.so.8: cannot open shared object file: No such file or directory
```