### PR TITLE
[DPE-9490] Replace GH skopeo with rockcraft.skopeo in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install rockcraft, tox & poetry
         run: |
-          sudo snap install rockcraft
+          sudo snap install rockcraft --classic
           pipx install tox
           pipx install poetry
       - name: Download rock(s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install rockcraft, tox & poetry
         run: |
-          snap install rockcraft
+          sudo snap install rockcraft
           pipx install tox
           pipx install poetry
       - name: Download rock(s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install tox & poetry
+      - name: Install rockcraft, tox & poetry
         run: |
+          snap install rockcraft
           pipx install tox
           pipx install poetry
       - name: Download rock(s)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -12,7 +12,7 @@ def test_upload():
         version = rockcraft["version"]
 
         subprocess.run([
-            "skopeo",
+            "rockcraft.skopeo",
             "copy",
             f"oci-archive:{name}_{version}_amd64.rock",
             f"docker-daemon:{name}:test",


### PR DESCRIPTION
# Issue

GH tests randomly failing with skopeo error, e.g.: `time="2026-02-17T12:03:25Z" level=fatal msg="writing blob: io: read/write on closed pipe"`
https://github.com/canonical/charmed-pgbouncer-rock/actions/runs/22084598817/job/63859005353?pr=100#step:5:28

In fact Canonical ships skopeo as part of rockcraft tool, but the test use the GH one, which is way older:

Rockcraft snap latest/stable v1.17.0 r4145: `skopeo version 1.20.0`
GH runner: `skopeo version 1.13.3`

# Solution

Use skopeo from rockcraft snap.