### PR TITLE
[DPE-9000] Add permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,18 @@ jobs:
   lint:
     name: Lint
     uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.0
+    permissions: {}
 
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.0
+    permissions: {}
+
   smoke:
     name: Smoke test rock
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     needs:
       - lint
       - build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,22 +9,20 @@ concurrency:
 on:
   pull_request:
 
+permissions: {}
 jobs:
   lint:
     name: Lint
     uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.0
-    permissions: {}
 
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.0
-    permissions: {}
 
   smoke:
     name: Smoke test rock
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     needs:
       - lint
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.0
+    permissions: {}
 
   release:
     name: Release rock
@@ -36,6 +37,7 @@ jobs:
       - build
       # Run after release so that rock cannot be (maliciously) modified between build & release
       - release
+    permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
# Issue

GH Security tab reports an issues due to missing default permission on workflow.

# Solution
    
Add permissions to workflows to keep the house clean.
